### PR TITLE
Web版のオーディオ設定を修正

### DIFF
--- a/lib/providers/audio_notifier.dart
+++ b/lib/providers/audio_notifier.dart
@@ -12,7 +12,7 @@ class AudioNotifier extends StateNotifier<AudioState> {
   final AudioPlayer sePlayer = AudioPlayer();
   AudioNotifier() : super(const AudioState(isMute: true)) {
     bgmPlayer.setReleaseMode(ReleaseMode.loop);
-    bgmPlayer.setVolume(0.2);
+    bgmPlayer.setVolume(0.15);
     if (!kIsWeb) {
       switchMute();
     }

--- a/lib/providers/audio_notifier.dart
+++ b/lib/providers/audio_notifier.dart
@@ -14,7 +14,7 @@ class AudioNotifier extends StateNotifier<AudioState> {
     bgmPlayer.setReleaseMode(ReleaseMode.loop);
     bgmPlayer.setVolume(0.2);
     if (!kIsWeb) {
-      onPressedMuteButton();
+      switchMute();
     }
   }
 
@@ -38,7 +38,7 @@ class AudioNotifier extends StateNotifier<AudioState> {
     _playSe(soundPath);
   }
 
-  void onPressedMuteButton() {
+  void switchMute() {
     if (state.isMute) {
       bgmPlayer.play(AssetSource(SoundPath.bgm));
       _setMute(false);

--- a/lib/ui_components/indigo_elevated_button.dart
+++ b/lib/ui_components/indigo_elevated_button.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class IndigoElevatedButton extends StatelessWidget {
+  const IndigoElevatedButton({
+    Key? key,
+    required this.onPressed,
+    required this.buttonText,
+  }) : super(key: key);
+  final void Function()? onPressed;
+  final String buttonText;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: Colors.indigo[900],
+      ),
+      child: Text(
+        buttonText,
+        style: const TextStyle(
+          fontSize: 20.0,
+          color: Colors.white,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui_components/indigo_elevated_button.dart
+++ b/lib/ui_components/indigo_elevated_button.dart
@@ -5,9 +5,11 @@ class IndigoElevatedButton extends StatelessWidget {
     Key? key,
     required this.onPressed,
     required this.buttonText,
+    this.fontSize,
   }) : super(key: key);
   final void Function()? onPressed;
   final String buttonText;
+  final double? fontSize;
 
   @override
   Widget build(BuildContext context) {
@@ -18,8 +20,8 @@ class IndigoElevatedButton extends StatelessWidget {
       ),
       child: Text(
         buttonText,
-        style: const TextStyle(
-          fontSize: 20.0,
+        style: TextStyle(
+          fontSize: fontSize,
           color: Colors.white,
         ),
       ),

--- a/lib/ui_components/web_initial_alert_dialog.dart
+++ b/lib/ui_components/web_initial_alert_dialog.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:omikuji_app/ui_components/indigo_elevated_button.dart';
+
+class WebInitialAlertDialog extends StatelessWidget {
+  const WebInitialAlertDialog({
+    Key? key,
+    required this.onPressed,
+  }) : super(key: key);
+  final void Function()? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return WillPopScope(
+      onWillPop: () async => false,
+      child: AlertDialog(
+        title: const Text('おみくじ'),
+        content: const Text('ボタンをタップしておみくじを引こう'),
+        actions: [
+          IndigoElevatedButton(
+            onPressed: onPressed,
+            buttonText: 'はじめる',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/omikuji_page.dart
+++ b/lib/views/omikuji_page.dart
@@ -82,6 +82,7 @@ class OmikujiPageState extends ConsumerState<OmikujiPage> {
                   child: IndigoElevatedButton(
                     onPressed: omikujiNotifier.drawOmikuji,
                     buttonText: 'おみくじを引く',
+                    fontSize: 20.0,
                   ),
                 ),
                 const SizedBox(height: 32.0),

--- a/lib/views/omikuji_page.dart
+++ b/lib/views/omikuji_page.dart
@@ -18,7 +18,7 @@ class OmikujiPage extends ConsumerStatefulWidget {
 class OmikujiPageState extends ConsumerState<OmikujiPage> {
   void _onPressedStartButton() {
     final notifier = ref.read(audioProvider.notifier);
-    notifier.onPressedMuteButton();
+    notifier.switchMute();
     Navigator.pop(context);
   }
 
@@ -55,7 +55,7 @@ class OmikujiPageState extends ConsumerState<OmikujiPage> {
           backgroundColor: Colors.indigo[900],
           actions: [
             IconButton(
-              onPressed: audioNotifier.onPressedMuteButton,
+              onPressed: audioNotifier.switchMute,
               icon: audioState.isMute
                   ? const Icon(Icons.volume_off_outlined)
                   : const Icon(Icons.volume_up_outlined),

--- a/lib/views/omikuji_page.dart
+++ b/lib/views/omikuji_page.dart
@@ -1,16 +1,49 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:omikuji_app/providers/audio_notifier.dart';
 import 'package:omikuji_app/providers/omikuji_notifier.dart';
+import 'package:omikuji_app/ui_components/indigo_elevated_button.dart';
+import 'package:omikuji_app/ui_components/web_initial_alert_dialog.dart';
 import 'package:omikuji_app/views/loading_view.dart';
 import 'package:omikuji_app/views/network_error_view.dart';
 import 'package:omikuji_app/views/result_view.dart';
 
-class OmikujiPage extends ConsumerWidget {
+class OmikujiPage extends ConsumerStatefulWidget {
   const OmikujiPage({Key? key}) : super(key: key);
+  @override
+  OmikujiPageState createState() => OmikujiPageState();
+}
+
+class OmikujiPageState extends ConsumerState<OmikujiPage> {
+  void _onPressedStartButton() {
+    final notifier = ref.read(audioProvider.notifier);
+    notifier.onPressedMuteButton();
+    Navigator.pop(context);
+  }
+
+  void _showWebInitialAlertDialog() {
+    Future(() {
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => WebInitialAlertDialog(
+          onPressed: _onPressedStartButton,
+        ),
+      );
+    });
+  }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  void initState() {
+    super.initState();
+    if (kIsWeb) {
+      _showWebInitialAlertDialog();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final omikujiState = ref.watch(omikujiProvider);
     final audioState = ref.watch(audioProvider);
     final omikujiNotifier = ref.watch(omikujiProvider.notifier);
@@ -46,18 +79,9 @@ class OmikujiPage extends ConsumerWidget {
                 const Spacer(),
                 SizedBox(
                   height: 48.0,
-                  child: ElevatedButton(
+                  child: IndigoElevatedButton(
                     onPressed: omikujiNotifier.drawOmikuji,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.indigo[900],
-                    ),
-                    child: const Text(
-                      'おみくじを引く',
-                      style: TextStyle(
-                        fontSize: 20.0,
-                        color: Colors.white,
-                      ),
-                    ),
+                    buttonText: 'おみくじを引く',
                   ),
                 ),
                 const SizedBox(height: 32.0),


### PR DESCRIPTION
## 実装したこと
* ElevatedButtonをUIコンポーネント化
* Web版で最初にアラートを表示
  * 閉じるボタンをタップでミュート解除
* BGMのsetVolumeを0.2から0.15に変更(全プラットフォーム共通)

## UI（Web版）
<img width="1440" alt="スクリーンショット 2023-01-02 11 56 15" src="https://user-images.githubusercontent.com/82624334/210192186-bbc0f574-2353-4417-b2b1-aba3f7ab5f1e.png">

