### PR TITLE
OSがAndroidとiOSの場合はMLKitで翻訳を行うように変更

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.omikuji_app"
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 21
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,6 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '15.5.0'
+$iOSVersion = '15.5.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -35,7 +36,18 @@ target 'Runner' do
 end
 
 post_install do |installer|
+  installer.pods_project.build_configurations.each do |config|
+    config.build_settings["EXCLUDED_ARCHS[sdk=*]"] = "armv7"
+    config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = $iOSVersion
+  end
+
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+
+    target.build_configurations.each do |config|
+      if Gem::Version.new($iOSVersion) > Gem::Version.new(config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'])
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = $iOSVersion
+      end
+    end
   end
 end

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -121,7 +121,6 @@
 				E0A16C2AEEF30817B08F71CE /* Pods-Runner.release.xcconfig */,
 				D29E3A7129D895A49BB3C7F1 /* Pods-Runner.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -140,6 +139,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				E3832D4805ABB9FFF9BF37C1 /* [CP] Embed Pods Frameworks */,
+				75E7EDA52CDAC79FC2CAF686 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -213,6 +213,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
+		};
+		75E7EDA52CDAC79FC2CAF686 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -335,6 +352,8 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=*]" = armv7;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -406,6 +425,8 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=*]" = armv7;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -461,6 +482,8 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				EXCLUDED_ARCHS = "";
+				"EXCLUDED_ARCHS[sdk=*]" = armv7;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/lib/utils/omikuji_util.dart
+++ b/lib/utils/omikuji_util.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:english_words/english_words.dart';
-import 'package:translator/translator.dart';
+import 'package:omikuji_app/utils/translator.dart';
 
 import '../models/fortune.dart';
 
@@ -34,13 +34,17 @@ class OmikujiUtil {
     }
   }
 
+  /// ランダムなメッセージを生成する。
+  ///
+  /// ランダムな英単語のペアを日本語に翻訳して変な日本語を生成することにより、
+  /// 変な日本語を生成している。
   static Future<String> generateMessage() async {
-    final translator = GoogleTranslator();
-    final Translation translation;
-    // スネークケースで英単語のペアを生成（アンダーバーを半角スペースに置き換える）
-    final wordPair = WordPair.random().asSnakeCase.replaceAll('_', ' ');
-    translation = await translator.translate(wordPair, from: 'en', to: 'ja');
-    return translation.toString();
+    // ランダムな英単語のペアを生成（アンダーバーで区切られているので半角スペースに置き換え）
+    final englishWordPair = WordPair.random().asSnakeCase.replaceAll('_', ' ');
+    final japaneseMessage = await Translator.translateEnglishIntoJapanese(
+      englishWordPair,
+    );
+    return japaneseMessage;
   }
 
   static String generateAdvice(Fortune fortune) {

--- a/lib/utils/translator.dart
+++ b/lib/utils/translator.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:google_mlkit_translation/google_mlkit_translation.dart';
+import 'package:translator/translator.dart';
+
+class Translator {
+  Translator._();
+
+  static Future<String> _translateEnglishIntoJapaneseByGoogleTranslator(
+    String englishText,
+  ) async {
+    final translator = GoogleTranslator();
+    final translation = await translator.translate(
+      englishText,
+      from: 'en',
+      to: 'ja',
+    );
+    return translation.text;
+  }
+
+  static Future<String> _translateEnglishIntoJapaneseOnDevice(
+    String englishText,
+  ) async {
+    final onDeviceTranslator = OnDeviceTranslator(
+      sourceLanguage: TranslateLanguage.english,
+      targetLanguage: TranslateLanguage.japanese,
+    );
+    final response = await onDeviceTranslator.translateText(englishText);
+    return response;
+  }
+
+  /// 英語を日本語に翻訳する。
+  ///
+  /// プラットフォームがAndroidまたはiOSの場合、Google MLKitを用いてon deviceで翻訳する。
+  /// それ以外のプラットフォームの場合、Google翻訳を用いて翻訳する。
+  static Future<String> translateEnglishIntoJapanese(
+    String englishText,
+  ) async {
+    String japaneseText;
+    if (Platform.isAndroid || Platform.isIOS) {
+      japaneseText = await _translateEnglishIntoJapaneseOnDevice(
+        englishText,
+      );
+    } else {
+      japaneseText = await _translateEnglishIntoJapaneseByGoogleTranslator(
+        englishText,
+      );
+    }
+    return japaneseText;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,9 +28,9 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  http: ^0.13.3
   english_words: ^4.0.0
   translator: ^0.1.7
+  google_mlkit_translation: ^0.12.0
   freezed_annotation: ^2.2.0
   flutter_hooks: ^0.20.5
   audioplayers: ^1.1.1


### PR DESCRIPTION
## 概要
OSがAndroidとiOSの場合はMLKitで翻訳を行うように変更を行いました。

## 実装したこと
* Translatorクラスの作成
* OSがAndroidとiOSの場合は翻訳をMLKitで行うように変更（それ以外のOSは今まで通りGoogle翻訳）
* MLKit導入に伴いAndroidとiOSの最低バージョンを変更